### PR TITLE
v0.1.2 - fixes parsing of Sheet JSON (and probably several others; TBD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 * based on https://keepachangelog.com/en/1.0.0/ and https://semver.org/
 * sections: Breaking Added Changed Deprecated Fixed Removed Security ToDo (in that order)
 
+## 0.1.2 - unreleased
+### Added
+* .
+### Changed
+* .
+### Fixed
+* .
+### Removed
+* .
+
 ## 0.1.1 - 2025-03-19
 ### Added
 * publish task so can start using this lib in other projects

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group               = "com.ronreynolds"
-version             = "0.1.1"
+version             = "0.1.2-SNAPSHOT"
 val buildDirectory  = layout.buildDirectory.get()
 val openapiSource   = "$rootDir/src/main/resources/smartsheet-v2-openapi-v3.0.3.json"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     //
     // needed by our code
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    implementation("org.slf4j:jul-to-slf4j:$slf4jVersion") // openapi-gen logs to java.util.logging; route it into slf4j/logback
     runtimeOnly   ("ch.qos.logback:logback-classic:$logbackVersion")
 
     //

--- a/src/main/java/com/ronreynolds/smartsheet/BasicUse.java
+++ b/src/main/java/com/ronreynolds/smartsheet/BasicUse.java
@@ -1,42 +1,53 @@
 package com.ronreynolds.smartsheet;
 
 import com.ronreynolds.smartsheet.api.ServerInfoApi;
-import com.ronreynolds.smartsheet.api.SheetsApi;
 import com.ronreynolds.smartsheet.api.UsersApi;
 import com.ronreynolds.smartsheet.api.util.ApiClients;
-import com.ronreynolds.smartsheet.model.SheetInclude;
+import com.ronreynolds.smartsheet.api.util.Sheets;
+import com.ronreynolds.smartsheet.model.CellObjectValue;
+import com.ronreynolds.smartsheet.model.Sheet;
+import com.ronreynolds.util.logging.JULIntoSLF4J;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.OffsetDateTime;
-import java.util.EnumSet;
-import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Slf4j
 public class BasicUse {
     public static void main(String[] args) {
-        // we need SOMETHING for this because the APIs don't support a null value
-        OffsetDateTime modifiedSince = OffsetDateTime.now();
+        // route codegen code logging into slf4j
+        JULIntoSLF4J.install();
+
         ApiClient client = ApiClients.getDefaultClient();
         try {
-            log.info("server info - {}", new ServerInfoApi(client).serverinfoGet());
-
-            UsersApi usersApi = new UsersApi(client);
-            var currentUser = usersApi.getCurrentUser(null);
-            log.info("current user - {}", currentUser);
-            var sameUser = usersApi.getUser(currentUser.getId());
-            log.info("same user? - {}", sameUser);
-            var userList = usersApi.listUsers(null, null, null, modifiedSince, null, null, null);
-            log.info("user list - {}", userList);
-
-            // WIP
-            if (true) {
-                SheetsApi sheetsApi = new SheetsApi(client);
-                var sheet = sheetsApi.getSheet(7290900052922244L, null, null, List.copyOf(EnumSet.allOf(SheetInclude.class)),
-                        null, null, null, null, null, null, null, null, null, null, modifiedSince);
-                log.info("sheet - {}", sheet);
-            }
+//            getServerInfo(client);
+//            getUserInfo(client);
+            getSheet(client);
         } catch (ApiException e) {
             log.error("failure", e);
         }
+    }
+
+    private static void getServerInfo(ApiClient client) throws ApiException {
+        log.info("server info - {}", new ServerInfoApi(client).serverinfoGet());
+    }
+
+    private static void getUserInfo(ApiClient client) throws ApiException {
+        UsersApi usersApi = new UsersApi(client);
+        var currentUser = usersApi.getCurrentUser(null);
+        log.info("current user - {}", currentUser);
+        var sameUser = usersApi.getUser(currentUser.getId());
+        log.info("same user? - {}", sameUser);
+        var userList = usersApi.listUsers(null, null, null, null, null, null, null);
+        log.info("user list - {}", userList);
+    }
+
+    private static void getSheet(ApiClient client) throws ApiException {
+        Logger.getLogger(CellObjectValue.class.getName()).log(Level.INFO, "info log");
+        Logger.getLogger(CellObjectValue.class.getName()).log(Level.FINE, "fine log");
+        Logger.getLogger(CellObjectValue.class.getName()).log(Level.FINER, "finer log");
+        Logger.getLogger(CellObjectValue.class.getName()).log(Level.FINEST, "finest log");
+        Sheet sheet = Sheets.getWholeSheet(client, 7290900052922244L);
+        log.info("sheet - {}", sheet);
     }
 }

--- a/src/main/java/com/ronreynolds/smartsheet/api/util/ApiClients.java
+++ b/src/main/java/com/ronreynolds/smartsheet/api/util/ApiClients.java
@@ -1,5 +1,6 @@
 package com.ronreynolds.smartsheet.api.util;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.ronreynolds.smartsheet.ApiClient;
 import com.ronreynolds.smartsheet.Configuration;
 import com.ronreynolds.util.config.Settings;
@@ -30,6 +31,7 @@ public class ApiClients {
     private static final String HEADER_USER_AGENT = "User-Agent";
 
     private static final AtomicReference<ApiClient> defaultClient = new AtomicReference<>();
+
     // simple logging flags for now
     @Setter
     private static volatile boolean logRequest = Settings.getBool("LOG_REQUEST", false);
@@ -113,8 +115,9 @@ public class ApiClients {
      */
     public static ApiClient createNewClient() {
         ApiClient client = new ApiClient();
+        // disable this feature; breaks parsing of more complex objects
+        client.setObjectMapper(client.getObjectMapper().disable(MapperFeature.ALLOW_COERCION_OF_SCALARS));
         client.updateBaseUri(server.baseUrl);
-
         client.setRequestInterceptor(builder -> prepRequest(builder, getHeaderMap()));
         client.setResponseInterceptor(ApiClients::processResponse);
 

--- a/src/main/java/com/ronreynolds/smartsheet/api/util/Constants.java
+++ b/src/main/java/com/ronreynolds/smartsheet/api/util/Constants.java
@@ -1,10 +1,14 @@
 package com.ronreynolds.smartsheet.api.util;
 
 import com.ronreynolds.smartsheet.model.AccessLevel;
+import com.ronreynolds.smartsheet.model.CompatibilityLevel;
 import com.ronreynolds.smartsheet.model.FolderInclude;
+import com.ronreynolds.smartsheet.model.PaperSize;
 import com.ronreynolds.smartsheet.model.ReportInclude;
+import com.ronreynolds.smartsheet.model.SheetExclude;
 import com.ronreynolds.smartsheet.model.SheetInclude;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -20,4 +24,17 @@ public class Constants {
     public static final List<ReportInclude> allReportIncludes = List.of(ReportInclude.values());
     public static final List<SheetInclude> allSheetIncludes = List.of(SheetInclude.values());
     public static final List<SheetInclude> normalSheetIncludes = List.of(SheetInclude.OWNER_INFO, SheetInclude.COLUMN_TYPE, SheetInclude.SOURCE);
+    public static final List<SheetExclude> noSheetExcludes = List.of();
+
+    public static final List<Long> allColumnIds = null;
+    public static final List<Long> allRowIds = null;
+    public static final List<Integer> allRowNumbers = null;
+
+    public static final String allFilters = null;
+    public static final Integer allPageNumbers = null;
+    public static final PaperSize noPaperSize = null;
+    public static final Integer noPageSize = null;
+    public static final OffsetDateTime noModifiedSince = null;
+    public static final Integer noVersionAfter = null;
+    public static final CompatibilityLevel noCompatibilityLevel = null;
 }

--- a/src/main/java/com/ronreynolds/smartsheet/api/util/Folders.java
+++ b/src/main/java/com/ronreynolds/smartsheet/api/util/Folders.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 /**
  * utility methods for working with Folders in the Smartsheet API
  */
+@SuppressWarnings("unused")
 public class Folders {
     private Folders() {
     }
@@ -47,7 +48,6 @@ public class Folders {
             Folder folderData = new FoldersApi(api).getFolder(folder.getId(), Constants.allFolderIncludes);
             if (folderData != null) {
                 // even tho the ref within an Optional is immutable our Folder type is not
-                folder.setFavorite(folderData.getFavorite());   // FIXME (deprecated)
                 folder.setFolders(folderData.getFolders());
                 folder.setReports(folderData.getReports());
                 folder.setSheets(folderData.getSheets());

--- a/src/main/java/com/ronreynolds/smartsheet/api/util/Rows.java
+++ b/src/main/java/com/ronreynolds/smartsheet/api/util/Rows.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+@SuppressWarnings("unused")
 public class Rows {
     private Rows() {
     }
@@ -33,8 +34,8 @@ public class Rows {
      *
      * @param originalRow the starting point for the new Row
      * @param rowUpdate   if provided is invoked with the new row before the Cells are added
-     * @param cellUpdate
-     * @return
+     * @param cellUpdate  used to update Cells in the new Row
+     * @return the newly-built Row
      */
     public static Row updateRow(Row originalRow, Consumer<Row.Builder> rowUpdate, BiConsumer<Row.Builder, List<Cell>> cellUpdate) {
         Row.Builder builder = originalRow.toBuilder();
@@ -55,7 +56,7 @@ public class Rows {
                 .append(", parentId:").append(row.getParentId())
 //                .append(", parentRowNum:").append(row.getParentRowNumber()) - deprecated (v1.1) and removed in v2
                 .append(", siblingId:").append(row.getSiblingId())
-                .append(", permalink:").append(row.getPermaLink())
+                .append(", permalink:").append(row.getPermalink())
                 .append(", version:").append(row.getVersion())
                 .append(", created:{by:").append(row.getCreatedBy()).append(", at:").append(row.getCreatedAt()).append('}')
                 .append(", modified:{by:").append(row.getModifiedBy()).append(", at:").append(row.getModifiedAt()).append('}')

--- a/src/main/java/com/ronreynolds/smartsheet/api/util/Sheets.java
+++ b/src/main/java/com/ronreynolds/smartsheet/api/util/Sheets.java
@@ -20,6 +20,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.ronreynolds.smartsheet.api.util.Constants.*;
+
 /**
  * a collection of utility methods for working with Sheets (and Rows and Cells); note, heavily commented out as i need
  * to rework most of this code to work with the OpenAPI-generated code instead of the Smartsheet-SDK code
@@ -87,28 +89,18 @@ public class Sheets {
         return buf.toString();
     }
 
-    static final List<SheetInclude> ALL_SHEET_INCLUSIONS = List.copyOf(EnumSet.allOf(SheetInclude.class));
-    static final List<SheetExclude> NO_SHEET_EXCLUSIONS = List.of();
-    static final List<Long> ALL_COLUMN_IDS = null;
-    static final String ALL_FILTERS = null;
-    static final Integer NO_PAGE_SIZE_LIMIT = null;
-    static final Integer ALL_PAGE_NUMBERS = null;
-    static final List<Long> ALL_ROW_IDS = null;
-    static final List<Integer> ALL_ROW_NUMBERS = null;
-    static final OffsetDateTime ROWS_MODIFIED_SINCE = OffsetDateTime.now();
-
     public static Sheet getWholeSheet(@NonNull ApiClient client, long sheetId) throws ApiException {
         return new SheetsApi(client)
-                .getSheet(sheetId, null, null, ALL_SHEET_INCLUSIONS, NO_SHEET_EXCLUSIONS, ALL_COLUMN_IDS, ALL_FILTERS, null, null,
-                        NO_PAGE_SIZE_LIMIT, ALL_PAGE_NUMBERS, null, ALL_ROW_IDS, ALL_ROW_NUMBERS, ROWS_MODIFIED_SINCE)
+                .getSheet(sheetId, null, null, allSheetIncludes, noSheetExcludes, allColumnIds, allFilters, noVersionAfter,
+                        noCompatibilityLevel, noPageSize, allPageNumbers, noPaperSize, allRowIds, allRowNumbers, noModifiedSince)
                 .getSheet();
     }
 
     public static Sheet getSheetNoRows(@NonNull ApiClient client, long sheetId) throws ApiException {
-        // FIXME - need to support a comma-sep list of enum values; not just a single value (or null)
         return new SheetsApi(client)
                 .getSheet(sheetId, null, null, List.of(SheetInclude.COLUMN_TYPE), List.of(SheetExclude.LINK_IN_FROM_CELL_DETAILS),
-                        ALL_COLUMN_IDS, ALL_FILTERS, null, null, NO_PAGE_SIZE_LIMIT, ALL_PAGE_NUMBERS, null, ALL_ROW_IDS, ALL_ROW_NUMBERS, null)
+                        allColumnIds, allFilters, noVersionAfter, noCompatibilityLevel, noPageSize, allPageNumbers, noPaperSize,
+                        allRowIds, allRowNumbers, noModifiedSince)
                 .getSheet();
     }
 

--- a/src/main/java/com/ronreynolds/util/logging/JULIntoSLF4J.java
+++ b/src/main/java/com/ronreynolds/util/logging/JULIntoSLF4J.java
@@ -1,0 +1,19 @@
+package com.ronreynolds.util.logging;
+
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import java.util.logging.Logger;
+
+/**
+ * the static block is guaranteed to only happen once (per ClassLoader hierarchy) and it will happen before install() is called
+ */
+public class JULIntoSLF4J {
+    static {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+        Logger.getLogger(JULIntoSLF4J.class.getName()).info("JUL->SLF4J installed");
+    }
+    public static void install() {
+        // triggers static block above ;-)
+    }
+}

--- a/src/main/resources/get-sheet.sh
+++ b/src/main/resources/get-sheet.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+SHEET_ID=${1}
+ACCEPTS="application/json, application/pdf, application/vnd.ms-excel, text/csv"
+ALL_INCLUDES="attachments%2CcolumnType%2CcrossSheetReferences%2Cdiscussions%2Cfilters%2CfilterDefinitions%2Cformat%2CganttConfig%2CobjectValue%2CownerInfo%2CrowPermalink%2Csource%2CwriterInfo"
+
+curl -v -H "Authorization: Bearer ${SMARTSHEET_ACCESS_TOKEN}" \
+ -H "Accept: ${ACCEPTS}" \
+ "https://api.smartsheet.com/2.0/sheets/${SHEET_ID}?include=${ALL_INCLUDES}"

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+    <timestamp key="timestamp" datePattern="yyyyMMdd-HHmmss" timeReference="contextBirth"/>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>         <!-- reset all previous level configurations of all j.u.l. loggers -->
+    </contextListener>
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <file>/tmp/smar-openapi-${timestamp}.log</file> <!-- /tmp/ cleanup should keep the disk use down -->
+        <encoder>
+            <pattern>%date %level [%thread] %logger{10} [%file:%line] -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.ronreynolds.smartsheet" level="info"/>
+
+    <root level="info">
+        <appender-ref ref="stdout" />
+        <appender-ref ref="file" />
+    </root>
+</configuration>

--- a/src/main/resources/smartsheet-v2-openapi-v3.0.3.json
+++ b/src/main/resources/smartsheet-v2-openapi-v3.0.3.json
@@ -8696,7 +8696,7 @@
                               "type": "boolean"
                             },
                             "objectValue": {
-                              "$ref": "#/components/schemas/CellObjectValue"
+                              "$ref": "#/components/schemas/CellObjectValueObj"
                             },
                             "formula": {
                               "description": "The formula for a cell, if set.",
@@ -14252,7 +14252,20 @@
             }
           },
           "objectValue": {
-            "$ref": "#/components/schemas/CellObjectValue"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/CellObjectValueObj"
+              }
+            ]
           },
           "overrideValidation": {
             "type": "boolean",
@@ -14263,7 +14276,7 @@
             "description": "Set to **false** to enable lenient parsing. Defaults to **true**. You can specify this attribute in a request, but it is never present in a response."
           },
           "value": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "string"
               },
@@ -14485,7 +14498,7 @@
             "description": "Only returned if the include query string parameter contains **columnType**."
           },
           "value": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "string"
               },
@@ -14504,7 +14517,8 @@
           }
         }
       },
-      "CellObjectValue": {
+      "CellObjectValueObj": {
+        "type": "object",
         "description": "The base object for values found in the **Cell.objectValue** attribute. Its **objectType** attribute indicates the type of the object. This object itself is not used directly.",
         "required": [
           "objectType"
@@ -14921,40 +14935,40 @@
             ]
           },
           "description": {
-            "type": "string",
-            "description": "Column description."
+            "description": "Column description.",
+            "type": "string"
           },
           "format": {
-            "type": "string",
-            "description": "The format descriptor (see [Formatting](../../#section/API-Basics/Formatting)). Only returned if the **include** query string parameter contains **format** and this column has a non-default format applied to it."
+            "description": "The format descriptor (see [Formatting](../../#section/API-Basics/Formatting)). Only returned if the **include** query string parameter contains **format** and this column has a non-default format applied to it.",
+            "type": "string"
           },
           "formula": {
             "description": "The formula for the column, if set.",
             "type": "string"
           },
           "hidden": {
-            "type": "boolean",
-            "description": "Indicates whether the column is hidden."
+            "description": "Indicates whether the column is hidden.",
+            "type": "boolean"
           },
           "id": {
+            "description": "Column Id.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Int64"
               }
-            ],
-            "description": "Column Id."
+            ]
           },
           "index": {
-            "type": "integer",
-            "description": "Column index or position. This number is zero-based."
+            "description": "Column index or position. This number is zero-based.",
+            "type": "integer"
           },
           "locked": {
-            "type": "boolean",
-            "description": "Indicates whether the column is locked. In a response, a value of **true** indicates that the column has been locked by the sheet owner or the admin."
+            "description": "Indicates whether the column is locked. In a response, a value of **true** indicates that the column has been locked by the sheet owner or the admin.",
+            "type": "boolean"
           },
           "lockedForUser": {
-            "type": "boolean",
-            "description": "Indicates whether the column is locked for the requesting user. This attribute may be present in a response, but cannot be specified in a request."
+            "description": "Indicates whether the column is locked for the requesting user. This attribute may be present in a response, but cannot be specified in a request.",
+            "type": "boolean"
           },
           "options": {
             "description": "Array of the options available for the column.",
@@ -14964,22 +14978,23 @@
             }
           },
           "primary": {
-            "type": "boolean",
-            "description": "Returned only if the column is the Primary Column (value = **true**)."
+            "description": "Returned only if the column is the Primary Column (value = **true**).",
+            "type": "boolean"
           },
           "symbol": {
-            "type": "string",
-            "description": "When applicable for **CHECKBOX** or **PICKLIST** column types. See [Symbol Columns](../../tag/columnsRelated#section/Column-Types/Symbol-Columns)."
+            "description": "When applicable for **CHECKBOX** or **PICKLIST** column types. See [Symbol Columns](../../tag/columnsRelated#section/Column-Types/Symbol-Columns).",
+            "type": "string"
           },
           "systemColumnType": {
+            "description": "See [System Columns](../../tag/columnsRelated#section/Column-Types).",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ColumnType_system"
               }
-            ],
-            "description": "See [System Columns](../../tag/columnsRelated#section/Column-Types)."
+            ]
           },
           "tags": {
+            "description": "Set of tags to indicate special columns. Each element in the array is set to one of the listed enum values.",
             "type": "array",
             "items": {
               "type": "string",
@@ -14999,37 +15014,36 @@
                 "BASELINE_END_DATE",
                 "BASELINE_VARIANCE"
               ]
-            },
-            "description": "Set of tags to indicate special columns. Each element in the array is set to one of the listed enum values."
+            }
           },
           "title": {
-            "type": "string",
-            "description": "Column title."
+            "description": "Column title.",
+            "type": "string"
           },
           "type": {
+            "description": "See [Column Types](../../tag/columnsRelated#section/Column-Types)",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ColumnType"
               }
-            ],
-            "description": "See [Column Types](../../tag/columnsRelated#section/Column-Types)"
+            ]
           },
           "validation": {
-            "type": "boolean",
-            "description": "Indicates whether validation has been enabled for the column (value = **true**)."
+            "description": "Indicates whether validation has been enabled for the column (value = **true**).",
+            "type": "boolean"
           },
           "version": {
+            "description": "* `0`: CONTACT_LIST, PICKLIST, or TEXT_NUMBER.\n* `1`: MULTI_CONTACT_LIST.\n* `2`: MULTI_PICKLIST.\n",
             "type": "integer",
             "enum": [
               0,
               1,
               2
-            ],
-            "description": "* `0`: CONTACT_LIST, PICKLIST, or TEXT_NUMBER.\n* `1`: MULTI_CONTACT_LIST.\n* `2`: MULTI_PICKLIST.\n"
+            ]
           },
           "width": {
-            "type": "integer",
-            "description": "Display width of the column in pixels."
+            "description": "Display width of the column in pixels.",
+            "type": "integer"
           }
         }
       },
@@ -15766,6 +15780,18 @@
           "value": "2025-03-03T16:59:59"
         }
       },
+      "DayOfWeek": {
+        "type": "string",
+        "enum": [
+          "MONDAY",
+          "TUESDAY",
+          "WEDNESDAY",
+          "THURSDAY",
+          "FRIDAY",
+          "SATURDAY",
+          "SUNDAY"
+        ]
+      },
       "DestinationContainerType": {
         "description": "Type of the destination container.",
         "type": "string",
@@ -15946,7 +15972,7 @@
           },
           "days": {
             "description": "Number of days",
-            "type": "integer",
+            "type": "number",
             "format": "float"
           }
         },
@@ -16178,6 +16204,64 @@
           "template",
           "workspace"
         ]
+      },
+      "Filter": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/Int64"
+          },
+          "filterType": {
+            "type": "string"
+          },
+          "query": {
+            "type": "object",
+            "properties": {
+              "operator": {
+                "type": "string"
+              },
+              "criteria": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FilterCriterion"
+                }
+              },
+              "includeParent": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "FilterCriterion": {
+        "type": "object",
+        "properties": {
+          "operator": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "columnId": {
+            "$ref": "#/components/schemas/Int64"
+          }
+        }
       },
       "Filters": {
         "description": "Smartsheet users can define and save personal column filters on sheets they can view.",
@@ -16906,6 +16990,23 @@
           "source"
         ]
       },
+      "Month": {
+        "type": "string",
+        "enum": [
+          "JANUARY",
+          "FEBRUARY",
+          "MARCH",
+          "APRIL",
+          "MAY",
+          "JUNE",
+          "JULY",
+          "AUGUST",
+          "SEPTEMBER",
+          "OCTOBER",
+          "NOVEMBER",
+          "DECEMBER"
+        ]
+      },
       "MoveRowsInclude": {
         "type": "string",
         "enum": [
@@ -16979,6 +17080,9 @@
           "name": {
             "type": "string",
             "readOnly": true
+          },
+          "systemUserType": {
+            "type": "string"
           }
         }
       },
@@ -17236,16 +17340,7 @@
           "workingDays": {
             "type": "array",
             "items": {
-              "type": "string",
-              "enum": [
-                "MONDAY",
-                "TUESDAY",
-                "WEDNESDAY",
-                "THURSDAY",
-                "FRIDAY",
-                "SATURDAY",
-                "SUNDAY"
-              ]
+              "$ref": "#/components/schemas/DayOfWeek"
             }
           }
         }
@@ -17839,7 +17934,7 @@
               }
             ]
           },
-          "permaLink": {
+          "permalink": {
             "description": "URL that represents a direct link to the row in Smartsheet. Only returned if the include query string parameter contains rowPermalink.",
             "type": "string"
           },
@@ -17852,7 +17947,7 @@
             "description": "Sheet version number that is incremented every time a sheet is modified.",
             "type": "integer"
           },
-          "parentId" :  {
+          "parentId": {
             "description": "Parent row Id.",
             "allOf": [
               {
@@ -17860,10 +17955,10 @@
               }
             ]
           },
-          "toTop" :  {
+          "toTop": {
             "type": "boolean"
           },
-          "toBottom" :  {
+          "toBottom": {
             "type": "boolean"
           },
           "above": {
@@ -18376,6 +18471,9 @@
       "Sheet": {
         "type": "object",
         "properties": {
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          },
           "id": {
             "description": "Sheet Id.",
             "allOf": [
@@ -18384,16 +18482,12 @@
               }
             ]
           },
+          "name": {
+            "description": "Sheet name.",
+            "type": "string"
+          },
           "fromId": {
             "description": "The Id of the template from which to create the sheet. This attribute can be specified in a request, but is never present in a response.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Int64"
-              }
-            ]
-          },
-          "ownerId": {
-            "description": "User Id of the sheet owner.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Int64"
@@ -18453,6 +18547,61 @@
             "type": "boolean",
             "deprecated": true
           },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Filter"
+            }
+          },
+          "ganttConfig": {
+            "type": "object",
+            "properties": {
+              "workingDays": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DayOfWeek"
+                }
+              },
+              "holidays": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "hoursInWorkingDay": {
+                "type": "number",
+                "format": "float"
+              },
+              "primaryHeading": {
+                "type": "object",
+                "properties": {
+                  "scale": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  }
+                }
+              },
+              "secondaryHeading": {
+                "type": "object",
+                "properties": {
+                  "scale": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  }
+                }
+              },
+              "firstDayOfWeek": {
+                "$ref": "#/components/schemas/DayOfWeek"
+              },
+              "fiscalYearBegins": {
+                "$ref": "#/components/schemas/Month"
+              }
+            }
+          },
           "ganttEnabled": {
             "description": "Indicates whether \"Gantt View\" is enabled.",
             "type": "boolean"
@@ -18468,13 +18617,17 @@
           "modifiedAt": {
             "$ref": "#/components/schemas/Datetime"
           },
-          "name": {
-            "description": "Sheet name.",
-            "type": "string"
-          },
           "owner": {
             "description": "Email address of the sheet owner.",
             "type": "string"
+          },
+          "ownerId": {
+            "description": "User Id of the sheet owner.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Int64"
+              }
+            ]
           },
           "permalink": {
             "description": "URL that represents a direct link to the sheet in Smartsheet.",
@@ -18511,9 +18664,6 @@
           "showParentRowsForFilters": {
             "description": "Returned only if there are column filters on the sheet. Value = **true** if \"show parent rows\" is enabled for the filters.",
             "type": "boolean"
-          },
-          "source": {
-            "$ref": "#/components/schemas/Source"
           },
           "summary": {
             "type": "object",
@@ -19405,7 +19555,7 @@
             ]
           },
           "objectValue": {
-            "$ref": "#/components/schemas/CellObjectValue"
+            "$ref": "#/components/schemas/CellObjectValueObj"
           },
           "options": {
             "description": "When applicable for PICKLIST column type. Array of the options available for the field.",

--- a/src/main/resources/templates/ApiClient.mustache
+++ b/src/main/resources/templates/ApiClient.mustache
@@ -165,14 +165,7 @@ public class ApiClient {
    * Create an instance of ApiClient.
    */
   public ApiClient() {
-    this.builder = createDefaultHttpClientBuilder();
-    this.mapper = createDefaultObjectMapper();
-    updateBaseUri(getDefaultBaseUri());
-    interceptor = null;
-    readTimeout = null;
-    connectTimeout = null;
-    responseInterceptor = null;
-    asyncResponseInterceptor = null;
+    this(createDefaultHttpClientBuilder(), createDefaultObjectMapper(), getDefaultBaseUri());
   }
 
   /**
@@ -209,7 +202,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  private static String getDefaultBaseUri() {
     return "{{{basePath}}}";
   }
 

--- a/src/main/resources/templates/api.mustache
+++ b/src/main/resources/templates/api.mustache
@@ -48,14 +48,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-{{#asyncNative}}
+import java.util.logging.Logger;
 
+{{#asyncNative}}
 import java.util.concurrent.CompletableFuture;
 {{/asyncNative}}
 
 {{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}} {
+  private static final Logger log = Logger.getLogger({{classname}}.class.getName());
+
   private final ApiClient apiClient;
   private final HttpClient memberVarHttpClient;
   private final ObjectMapper memberVarObjectMapper;
@@ -298,6 +301,7 @@ public class {{classname}} {
 
         String responseBody = new String(localVarResponse.body().readAllBytes());
         localVarResponse.body().close();
+        log.finest("response-body:\n" + responseBody);
 
         return new ApiResponse<{{{returnType}}}>(
             localVarResponse.statusCode(),

--- a/src/main/resources/templates/oneof_model.mustache
+++ b/src/main/resources/templates/oneof_model.mustache
@@ -1,0 +1,396 @@
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import {{invokerPackage}}.ApiClient;
+import {{invokerPackage}}.JSON;
+
+{{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{>xmlAnnotation}}
+@JsonDeserialize(using = {{classname}}.{{classname}}Deserializer.class)
+@JsonSerialize(using = {{classname}}.{{classname}}Serializer.class)
+public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-implements}} implements {{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-implements}} {
+    private static final Logger log = Logger.getLogger({{classname}}.class.getName());
+
+    public static class {{classname}}Serializer extends StdSerializer<{{classname}}> {
+        public {{classname}}Serializer(Class<{{classname}}> t) {
+            super(t);
+        }
+
+        public {{classname}}Serializer() {
+            this(null);
+        }
+
+        @Override
+        public void serialize({{classname}} value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+            jgen.writeObject(value.getActualInstance());
+        }
+    }
+
+    public static class {{classname}}Deserializer extends StdDeserializer<{{classname}}> {
+        public {{classname}}Deserializer() {
+            this({{classname}}.class);
+        }
+
+        public {{classname}}Deserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public {{classname}} deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            JsonNode tree = jp.readValueAsTree();
+            Object deserialized = null;
+            {{#useOneOfDiscriminatorLookup}}
+            {{#discriminator}}
+            {{classname}} new{{classname}} = new {{classname}}();
+            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            String discriminatorValue = (String)result2.get("{{{propertyBaseName}}}");
+            switch (discriminatorValue) {
+            {{#mappedModels}}
+                case "{{{mappingName}}}":
+                    deserialized = tree.traverse(jp.getCodec()).readValueAs({{{modelName}}}.class);
+                    new{{classname}}.setActualInstance(deserialized);
+                    return new{{classname}};
+            {{/mappedModels}}
+                default:
+                    log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorValue));
+            }
+
+            {{/discriminator}}
+            {{/useOneOfDiscriminatorLookup}}
+            boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+            int match = 0;
+            JsonToken token = tree.traverse(jp.getCodec()).nextToken();
+            {{#oneOf}}
+            // deserialize {{{.}}}
+            try {
+                boolean attemptParsing = true;
+                // ensure that we respect type coercion as set on the client ObjectMapper
+                if ({{{.}}}.class.equals(Integer.class) || {{{.}}}.class.equals(Long.class) || {{{.}}}.class.equals(Float.class) || {{{.}}}.class.equals(Double.class) || {{{.}}}.class.equals(Boolean.class) || {{{.}}}.class.equals(String.class)) {
+                    attemptParsing = typeCoercion;
+                    if (!attemptParsing) {
+                        attemptParsing |= (({{{.}}}.class.equals(Integer.class) || {{{.}}}.class.equals(Long.class)) && token == JsonToken.VALUE_NUMBER_INT);
+                        attemptParsing |= (({{{.}}}.class.equals(Float.class) || {{{.}}}.class.equals(Double.class)) && token == JsonToken.VALUE_NUMBER_FLOAT);
+                        attemptParsing |= ({{{.}}}.class.equals(Boolean.class) && (token == JsonToken.VALUE_FALSE || token == JsonToken.VALUE_TRUE));
+                        attemptParsing |= ({{{.}}}.class.equals(String.class) && token == JsonToken.VALUE_STRING);
+                        {{#isNullable}}
+                        attemptParsing |= (token == JsonToken.VALUE_NULL);
+                        {{/isNullable}}
+                    }
+                }
+                if (attemptParsing) {
+                    deserialized = tree.traverse(jp.getCodec()).readValueAs({{{.}}}.class);
+                    // TODO: there is no validation against JSON schema constraints
+                    // (min, max, enum, pattern...), this does not perform a strict JSON
+                    // validation, which means the 'match' count may be higher than it should be.
+                    match++;
+                    log.log(Level.FINER, "Input data matches schema '{{{.}}}'");
+                }
+            } catch (Exception e) {
+                // deserialization failed, continue
+                log.log(Level.FINER, "Input data does not match schema '{{{.}}}'", e);
+            }
+
+            {{/oneOf}}
+            if (match == 1) {
+                {{classname}} ret = new {{classname}}();
+                ret.setActualInstance(deserialized);
+                return ret;
+            }
+            throw new IOException(String.format("Failed deserialization for {{classname}}: %d classes match result, expected 1", match));
+        }
+
+        /**
+         * Handle deserialization of the 'null' value.
+         */
+        @Override
+        public {{classname}} getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        {{#isNullable}}
+            return null;
+        {{/isNullable}}
+        {{^isNullable}}
+            throw new JsonMappingException(ctxt.getParser(), "{{classname}} cannot be null");
+        {{/isNullable}}
+        }
+    }
+
+    // store a list of schema names defined in oneOf
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
+
+    public {{classname}}() {
+        super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
+    }
+{{> libraries/native/additional_properties }}
+    {{#additionalPropertiesType}}
+    /**
+     * Return true if this {{name}} object is equal to o.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o) && Objects.equals(this.additionalProperties, (({{classname}})o).additionalProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getActualInstance(), isNullable(), getSchemaType(), additionalProperties);
+    }
+    {{/additionalPropertiesType}}
+    {{#oneOf}}
+    public {{classname}}({{{.}}} o) {
+        super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
+        setActualInstance(o);
+    }
+
+    {{/oneOf}}
+    static {
+        {{#oneOf}}
+        schemas.put("{{{.}}}", {{{.}}}.class);
+        {{/oneOf}}
+        JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
+        {{#discriminator}}
+        // Initialize and register the discriminator mappings.
+        Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
+        {{#mappedModels}}
+        mappings.put("{{mappingName}}", {{modelName}}.class);
+        {{/mappedModels}}
+        mappings.put("{{name}}", {{classname}}.class);
+        JSON.registerDiscriminator({{classname}}.class, "{{propertyBaseName}}", mappings);
+        {{/discriminator}}
+    }
+
+    @Override
+    public Map<String, Class<?>> getSchemas() {
+        return {{classname}}.schemas;
+    }
+
+    /**
+     * Set the instance that matches the oneOf child schema, check
+     * the instance parameter is valid against the oneOf child schemas:
+     * {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}
+     *
+     * It could be an instance of the 'oneOf' schemas.
+     * The oneOf child schemas may themselves be a composed schema (allOf, anyOf, oneOf).
+     */
+    @Override
+    public void setActualInstance(Object instance) {
+        {{#isNullable}}
+        if (instance == null) {
+           super.setActualInstance(instance);
+           return;
+        }
+
+        {{/isNullable}}
+        {{#oneOf}}
+        if (JSON.isInstanceOf({{{.}}}.class, instance, new HashSet<Class<?>>())) {
+            super.setActualInstance(instance);
+            return;
+        }
+
+        {{/oneOf}}
+        throw new RuntimeException("Invalid instance type. Must be {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}");
+    }
+
+    /**
+     * Get the actual instance, which can be the following:
+     * {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}
+     *
+     * @return The actual instance ({{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}})
+     */
+    @Override
+    public Object getActualInstance() {
+        return super.getActualInstance();
+    }
+
+    {{#oneOf}}
+    /**
+     * Get the actual instance of `{{{.}}}`. If the actual instance is not `{{{.}}}`,
+     * the ClassCastException will be thrown.
+     *
+     * @return The actual instance of `{{{.}}}`
+     * @throws ClassCastException if the instance is not `{{{.}}}`
+     */
+    public {{{.}}} get{{{.}}}() throws ClassCastException {
+        return ({{{.}}})super.getActualInstance();
+    }
+
+    {{/oneOf}}
+
+{{#supportUrlQuery}}
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @return URL query string
+   */
+  public String toUrlQueryString() {
+    return toUrlQueryString(null);
+  }
+
+  /**
+   * Convert the instance into URL query string.
+   *
+   * @param prefix prefix of the query string
+   * @return URL query string
+   */
+  public String toUrlQueryString(String prefix) {
+    String suffix = "";
+    String containerSuffix = "";
+    String containerPrefix = "";
+    if (prefix == null) {
+      // style=form, explode=true, e.g. /pet?name=cat&type=manx
+      prefix = "";
+    } else {
+      // deepObject style e.g. /pet?id[name]=cat&id[type]=manx
+      prefix = prefix + "[";
+      suffix = "]";
+      containerSuffix = "]";
+      containerPrefix = "[";
+    }
+
+    StringJoiner joiner = new StringJoiner("&");
+
+    {{#composedSchemas.oneOf}}
+    {{^vendorExtensions.x-duplicated-data-type}}
+    if (getActualInstance() instanceof {{{dataType}}}) {
+        {{#isArray}}
+        {{#items.isPrimitiveType}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{{items.dataType}}} _item : ({{{dataType}}})getActualInstance()) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(String.valueOf(_item))));
+          }
+          i++;
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(String.valueOf(getActualInstance().get(i)))));
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isPrimitiveType}}
+        {{^items.isPrimitiveType}}
+        {{#items.isModel}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{{items.dataType}}} _item : ({{{dataType}}})getActualInstance()) {
+            if (_item != null) {
+              joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+            }
+          }
+          i++;
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            if ((({{{dataType}}})getActualInstance()).get(i) != null) {
+              joiner.add((({{{items.dataType}}})getActualInstance()).get(i).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
+            }
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isModel}}
+        {{^items.isModel}}
+        {{#uniqueItems}}
+        if (getActualInstance() != null) {
+          int i = 0;
+          for ({{{items.dataType}}} _item : ({{{dataType}}})getActualInstance()) {
+            if (_item != null) {
+              joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  ApiClient.urlEncode(String.valueOf(_item))));
+            }
+            i++;
+          }
+        }
+        {{/uniqueItems}}
+        {{^uniqueItems}}
+        if (getActualInstance() != null) {
+          for (int i = 0; i < (({{{dataType}}})getActualInstance()).size(); i++) {
+            if (getActualInstance().get(i) != null) {
+              joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  ApiClient.urlEncode(String.valueOf((({{{dataType}}})getActualInstance()).get(i)))));
+            }
+          }
+        }
+        {{/uniqueItems}}
+        {{/items.isModel}}
+        {{/items.isPrimitiveType}}
+        {{/isArray}}
+        {{^isArray}}
+        {{#isMap}}
+        {{#items.isPrimitiveType}}
+        if (getActualInstance() != null) {
+          for (String _key : (({{{dataType}}})getActualInstance()).keySet()) {
+            joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
+                "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                getActualInstance().get(_key), ApiClient.urlEncode(String.valueOf((({{{dataType}}})getActualInstance()).get(_key)))));
+          }
+        }
+        {{/items.isPrimitiveType}}
+        {{^items.isPrimitiveType}}
+        if (getActualInstance() != null) {
+          for (String _key : (({{{dataType}}})getActualInstance()).keySet()) {
+            if ((({{{dataType}}})getActualInstance()).get(_key) != null) {
+              joiner.add((({{{items.dataType}}})getActualInstance()).get(_key).toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
+                  "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, _key, containerSuffix))));
+            }
+          }
+        }
+        {{/items.isPrimitiveType}}
+        {{/isMap}}
+        {{^isMap}}
+        {{#isPrimitiveType}}
+        if (getActualInstance() != null) {
+          joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, ApiClient.urlEncode(String.valueOf(getActualInstance()))));
+        }
+        {{/isPrimitiveType}}
+        {{^isPrimitiveType}}
+        {{#isModel}}
+        if (getActualInstance() != null) {
+          joiner.add((({{{dataType}}})getActualInstance()).toUrlQueryString(prefix + "{{{baseName}}}" + suffix));
+        }
+        {{/isModel}}
+        {{^isModel}}
+        if (getActualInstance() != null) {
+          joiner.add(String.format("%s{{{baseName}}}%s=%s", prefix, suffix, ApiClient.urlEncode(String.valueOf(getActualInstance()))));
+        }
+        {{/isModel}}
+        {{/isPrimitiveType}}
+        {{/isMap}}
+        {{/isArray}}
+        return joiner.toString();
+    }
+    {{/vendorExtensions.x-duplicated-data-type}}
+    {{/composedSchemas.oneOf}}
+    return null;
+  }
+{{/supportUrlQuery}}
+
+}

--- a/src/main/resources/templates/oneof_model.mustache
+++ b/src/main/resources/templates/oneof_model.mustache
@@ -1,14 +1,16 @@
 import java.io.IOException;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,6 +28,7 @@ import {{invokerPackage}}.JSON;
 @JsonSerialize(using = {{classname}}.{{classname}}Serializer.class)
 public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-implements}} implements {{{.}}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-implements}} {
     private static final Logger log = Logger.getLogger({{classname}}.class.getName());
+    private static final Set<Class<?>> scalarTypes = Set.of(Integer.class, Long.class, Float.class, Double.class, Boolean.class, String.class);
 
     public static class {{classname}}Serializer extends StdSerializer<{{classname}}> {
         public {{classname}}Serializer(Class<{{classname}}> t) {
@@ -53,35 +56,38 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
         @Override
         public {{classname}} deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-            JsonNode tree = jp.readValueAsTree();
-            Object deserialized = null;
+            final JsonNode tree = jp.readValueAsTree();
+            final ObjectCodec codec = jp.getCodec();
             {{#useOneOfDiscriminatorLookup}}
             {{#discriminator}}
             {{classname}} new{{classname}} = new {{classname}}();
-            Map<String,Object> result2 = tree.traverse(jp.getCodec()).readValueAs(new TypeReference<Map<String, Object>>() {});
+            Map<String,Object> result2 = tree.traverse(codec).readValueAs(new TypeReference<Map<String, Object>>() {});
             String discriminatorValue = (String)result2.get("{{{propertyBaseName}}}");
             switch (discriminatorValue) {
             {{#mappedModels}}
                 case "{{{mappingName}}}":
-                    deserialized = tree.traverse(jp.getCodec()).readValueAs({{{modelName}}}.class);
-                    new{{classname}}.setActualInstance(deserialized);
-                    return new{{classname}};
+                    return new{{classname}}.actualInstance(tree.traverse(codec).readValueAs({{{modelName}}}.class));
             {{/mappedModels}}
                 default:
-                    log.log(Level.WARNING, String.format("Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}", discriminatorValue));
+                    log.warning(String.format(
+                        "Failed to lookup discriminator value `%s` for {{classname}}. Possible values:{{#mappedModels}} {{{mappingName}}}{{/mappedModels}}",
+                        discriminatorValue));
             }
 
             {{/discriminator}}
             {{/useOneOfDiscriminatorLookup}}
-            boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
-            int match = 0;
-            JsonToken token = tree.traverse(jp.getCodec()).nextToken();
+            final boolean typeCoercion = ctxt.isEnabled(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+            final List<String> matchingTypes = new ArrayList<>();
+            final JsonToken token = tree.traverse(codec).nextToken();
+            Object deserialized = null;
+
+            log.fine("parsing token:" + token + " tree:'" + tree + "'");
             {{#oneOf}}
             // deserialize {{{.}}}
             try {
                 boolean attemptParsing = true;
                 // ensure that we respect type coercion as set on the client ObjectMapper
-                if ({{{.}}}.class.equals(Integer.class) || {{{.}}}.class.equals(Long.class) || {{{.}}}.class.equals(Float.class) || {{{.}}}.class.equals(Double.class) || {{{.}}}.class.equals(Boolean.class) || {{{.}}}.class.equals(String.class)) {
+                if (scalarTypes.contains({{{.}}}.class)) {
                     attemptParsing = typeCoercion;
                     if (!attemptParsing) {
                         attemptParsing |= (({{{.}}}.class.equals(Integer.class) || {{{.}}}.class.equals(Long.class)) && token == JsonToken.VALUE_NUMBER_INT);
@@ -94,25 +100,23 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     }
                 }
                 if (attemptParsing) {
-                    deserialized = tree.traverse(jp.getCodec()).readValueAs({{{.}}}.class);
+                    deserialized = tree.traverse(codec).readValueAs({{{.}}}.class);
                     // TODO: there is no validation against JSON schema constraints
                     // (min, max, enum, pattern...), this does not perform a strict JSON
                     // validation, which means the 'match' count may be higher than it should be.
-                    match++;
-                    log.log(Level.FINER, "Input data matches schema '{{{.}}}'");
+                    matchingTypes.add("{{{.}}}");
+                    log.finer("Input data matches schema '{{{.}}}'");
                 }
             } catch (Exception e) {
                 // deserialization failed, continue
-                log.log(Level.FINER, "Input data does not match schema '{{{.}}}'", e);
+                log.finer("Input data does not match schema '{{{.}}}'");
             }
 
             {{/oneOf}}
-            if (match == 1) {
-                {{classname}} ret = new {{classname}}();
-                ret.setActualInstance(deserialized);
-                return ret;
+            if (matchingTypes.size() == 1) {
+                return new {{classname}}().actualInstance(deserialized);
             }
-            throw new IOException(String.format("Failed deserialization for {{classname}}: %d classes match result, expected 1", match));
+            throw new IOException(String.format("Failed deserialization for {{classname}}: matching types:%s, expected 1", matchingTypes));
         }
 
         /**

--- a/src/test/java/com/ronreynolds/smartsheet/model/SheetParsingTest.java
+++ b/src/test/java/com/ronreynolds/smartsheet/model/SheetParsingTest.java
@@ -1,0 +1,34 @@
+package com.ronreynolds.smartsheet.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ronreynolds.smartsheet.ApiClient;
+import com.ronreynolds.util.logging.JULIntoSLF4J;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SheetParsingTest {
+    static {
+        JULIntoSLF4J.install();
+    }
+    @Test
+    void parseSheetJson() {
+        String responseBody = assertDoesNotThrow(() -> Files.readString(Path.of("src/test/resources/raw-sheet.json")));
+        ApiClient client = new ApiClient();
+        ObjectMapper mapper = client.getObjectMapper().disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
+        // code copied (more or less) from com.ronreynolds.smartsheet.api.SheetsApi.getSheetWithHttpInfo()
+        GetSheet200Response response = assertDoesNotThrow(
+                () -> mapper.readValue(responseBody, new TypeReference<GetSheet200Response>() {}));
+        assertThat(response).isNotNull();
+        Sheet sheet = response.getSheet();
+        assertThat(sheet).isNotNull();
+        assertThat(sheet.getColumns()).hasSize(16);
+        assertThat(sheet.getRows()).hasSize(422);
+    }
+}


### PR DESCRIPTION
## 0.1.2 - 2025-03-20
### Added
* `logback.xml`
* code and library to redirect `java.util.logging` (used by generated code) into SLF4J
  * `JULIntoSLF4J.install()` should be used by other libraries to enable this behavior (idempotent)
* `get-sheet.sh` for testing SMAR API via curl
* a bit more logging to the generated code to help with debugging API/JSON issues
* more `Constants` fields
* `Sheet.ganntConfig`, `filters`, `Filter`, `FilterCriterion` to match Sheet JSON response
* `oneof_model.mustache` to allow changes (mostly logging and some code cleanup) to how JSON is parsed
### Changed
* `ApiClient.mustache` to generate somewhat cleaner code
* `api.mustache` to log the response body at finest level
* `Row.getPermaLink()` to `Row.getPermalink()` to match field name case in JSON
* `CellObjectValue` -> `CellObjectValueObj` to avoid name conflict with generated class for `Cell.objectValue` field value type
### Fixed
* parsing of Sheet JSON
  * added `CellObjectValueObj` to avoid conflict with generated `CellObjectValue` type for `Cell.objectValue` field value
  * disabled `MapperFeature.ALLOW_COERCION_OF_SCALARS` in `ApiClient`'s `ObjectMapper` to avoid parsing conflicts
### Removed
* `MapperFeature.ALLOW_COERCION_OF_SCALARS` to avoid scalar type conflicts when parsing certain JSON fields
* copying of `Folder.favorite` (now deprecated)
